### PR TITLE
Use editor as parent for the symbols menu

### DIFF
--- a/symbols/symbols.py
+++ b/symbols/symbols.py
@@ -8,12 +8,12 @@ config = mw.addonManager.getConfig(__name__)
 
 
 def onSymbolButton(self):
-    main = QMenu(mw)
+    main = QMenu(self.widget)
 
     last = main.addAction("Last Used: %s" % config["last_used"])
     last.triggered.connect(symbolFactory(self, config["last_used"]))
 
-    faves = QMenu("Favourites", mw)
+    faves = QMenu("Favourites", self.widget)
     main.addMenu(faves)
 
     faves_list = list(config['favourites'])
@@ -24,7 +24,7 @@ def onSymbolButton(self):
         a.triggered.connect(symbolFactory(self, char))
 
     for k, v in char_sets.items():
-        tmp_menu = QMenu(k, mw)
+        tmp_menu = QMenu(k, self.widget)
         main.addMenu(tmp_menu)
 
         chars = list(v)


### PR DESCRIPTION
Fixes that the symbols menu is opened hidden behind the editor or browser window.

Tested on Anki version ⁨2.1.56 (bb43e016)⁩, Python 3.9.15 Qt 6.4.0 PyQt 6.4.0
Debian bullseye